### PR TITLE
Issue #83 - remove unused extension point buildDirTree

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ImageViewerExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ImageViewerExtension.java
@@ -1,7 +1,6 @@
 package ca.corbett.imageviewer.extensions;
 
 import ca.corbett.extensions.AppExtension;
-import ca.corbett.extras.dirtree.DirTree;
 import ca.corbett.extras.logging.LogConsoleStyle;
 import ca.corbett.imageviewer.ImageOperation;
 import ca.corbett.imageviewer.ui.ImageInstance;
@@ -129,15 +128,6 @@ public abstract class ImageViewerExtension extends AppExtension {
         return false;
     }
 
-    /**
-     * Invoked when MainWindow wants to create the main DirTree - an extension can return
-     * some customized DirTree which will be used in place of the default one.
-     *
-     * @return A DirTree instance, or null.
-     */
-    public DirTree buildDirTree() {
-        return null;
-    }
 
     /**
      * Extensions can return a list of LogConsoleStyles to be applied to the ImageViewer

--- a/src/main/java/ca/corbett/imageviewer/extensions/ImageViewerExtensionManager.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ImageViewerExtensionManager.java
@@ -1,7 +1,6 @@
 package ca.corbett.imageviewer.extensions;
 
 import ca.corbett.extensions.ExtensionManager;
-import ca.corbett.extras.dirtree.DirTree;
 import ca.corbett.extras.logging.LogConsoleStyle;
 import ca.corbett.imageviewer.AppConfig;
 import ca.corbett.imageviewer.ImageOperation;
@@ -226,23 +225,6 @@ public class ImageViewerExtensionManager extends ExtensionManager<ImageViewerExt
             wasHandled = wasHandled || extension.handleKeyboardShortcut(e); // we could stop if one returns true...
         }
         return wasHandled;
-    }
-
-    /**
-     * Gives all extensions a chance to override the default DirTree instance creation
-     * for the MainWindow.The first extension to return a non-null value here
-     * is what will be used. If all extensions return null, the default instance is used.
-     *
-     * @return A DirTree instance, or null.
-     */
-    public DirTree buildDirTree() {
-        for (ImageViewerExtension extension : getEnabledLoadedExtensions()) {
-            DirTree dirTree = extension.buildDirTree();
-            if (dirTree != null) {
-                return dirTree;
-            }
-        }
-        return null;
     }
 
     /**

--- a/src/main/resources/ca/corbett/imageviewer/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/ReleaseNotes.txt
@@ -2,6 +2,7 @@ ImageViewer Release Notes
 Author: Steve Corbett
 
 Version 3.0 [TODO] - Maintenance release
+  #83 - Remove unused extension point: buildDirTree
   #76 - Upgrade to swing-extras 2.7
   #74 - Ensure image thumbnails are disposed properly
 


### PR DESCRIPTION
This PR addresses issue #83 by removing an unused extension point that allowed application extensions to supply a custom `DirTree` instance to the application. 
