### PR TITLE
Issue #90 - workaround for KeyStrokeProperty bug

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/AppConfig.java
+++ b/src/main/java/ca/corbett/imageviewer/AppConfig.java
@@ -17,6 +17,7 @@ import ca.corbett.forms.fields.FormField;
 import ca.corbett.imageviewer.extensions.ImageViewerExtension;
 import ca.corbett.imageviewer.extensions.ImageViewerExtensionManager;
 import ca.corbett.imageviewer.ui.MainWindow;
+import ca.corbett.imageviewer.ui.ReservedKeyStrokeWorkaround;
 import ca.corbett.imageviewer.ui.actions.AboutAction;
 import ca.corbett.imageviewer.ui.actions.DeleteCurrentAction;
 import ca.corbett.imageviewer.ui.actions.ExitAction;
@@ -454,27 +455,37 @@ public class AppConfig extends AppProperties<ImageViewerExtension> {
                                         "Refresh:",
                                         parseKeyStroke("F5"),
                                         new ReloadAction(MenuManager.MENU_ICON_SIZE))
-                          .setAllowBlank(true));
+                          .setAllowBlank(true)
+                          //.setReservedKeyStrokes(RESERVED_KEYSTROKES) // TODO does not work
+                          .addFormFieldGenerationListener(new ReservedKeyStrokeWorkaround())); // workaround
         props.add(new KeyStrokeProperty(KEY_RENAME,
                                         "Rename image:",
                                         parseKeyStroke("F2"),
                                         new RenameAction(MenuManager.MENU_ICON_SIZE))
-                          .setAllowBlank(true));
+                          .setAllowBlank(true)
+                          //.setReservedKeyStrokes(RESERVED_KEYSTROKES) // TODO does not work
+                          .addFormFieldGenerationListener(new ReservedKeyStrokeWorkaround())); // workaround
         props.add(new KeyStrokeProperty(KEY_BROWSE_MODE_FILESYSTEM,
                                         "Filesystem mode:",
                                         parseKeyStroke("alt+1"),
                                         new SetBrowseModeAction(MainWindow.BrowseMode.FILE_SYSTEM))
-                          .setAllowBlank(true));
+                          .setAllowBlank(true)
+                          //.setReservedKeyStrokes(RESERVED_KEYSTROKES) // TODO does not work
+                          .addFormFieldGenerationListener(new ReservedKeyStrokeWorkaround())); // workaround
         props.add(new KeyStrokeProperty(KEY_BROWSE_MODE_IMAGE_SET,
                                         "Image set mode:",
                                         parseKeyStroke("alt+2"),
                                         new SetBrowseModeAction(MainWindow.BrowseMode.IMAGE_SET))
-                          .setAllowBlank(true));
+                          .setAllowBlank(true)
+                          //.setReservedKeyStrokes(RESERVED_KEYSTROKES) // TODO does not work
+                          .addFormFieldGenerationListener(new ReservedKeyStrokeWorkaround())); // workaround
         props.add(new KeyStrokeProperty(KEY_ABOUT,
                                         "About dialog:",
                                         parseKeyStroke("Ctrl+A"),
                                         new AboutAction(MenuManager.MENU_ICON_SIZE))
-                          .setAllowBlank(true));
+                          .setAllowBlank(true)
+                          //.setReservedKeyStrokes(RESERVED_KEYSTROKES) // TODO does not work
+                          .addFormFieldGenerationListener(new ReservedKeyStrokeWorkaround())); // workaround
 
         return props;
     }

--- a/src/main/java/ca/corbett/imageviewer/extensions/builtin/ImageInfoExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/builtin/ImageInfoExtension.java
@@ -9,6 +9,7 @@ import ca.corbett.imageviewer.AppConfig;
 import ca.corbett.imageviewer.Version;
 import ca.corbett.imageviewer.extensions.ImageViewerExtension;
 import ca.corbett.imageviewer.ui.MainWindow;
+import ca.corbett.imageviewer.ui.ReservedKeyStrokeWorkaround;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,7 +59,8 @@ public class ImageInfoExtension extends ImageViewerExtension {
                                                        KeyStrokeManager.parseKeyStroke("Ctrl+I"),
                                                        imageInfoAction);
         prop.setAllowBlank(true);
-        prop.setReservedKeyStrokes(AppConfig.RESERVED_KEYSTROKES);
+        //prop.setReservedKeyStrokes(AppConfig.RESERVED_KEYSTROKES); // TODO does not work
+        prop.addFormFieldGenerationListener(new ReservedKeyStrokeWorkaround()); // Temporary workaround
         return List.of(prop);
     }
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/builtin/RepeatUndoExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/builtin/RepeatUndoExtension.java
@@ -8,6 +8,7 @@ import ca.corbett.imageviewer.AppConfig;
 import ca.corbett.imageviewer.Version;
 import ca.corbett.imageviewer.extensions.ImageViewerExtension;
 import ca.corbett.imageviewer.ui.MainWindow;
+import ca.corbett.imageviewer.ui.ReservedKeyStrokeWorkaround;
 
 import javax.swing.KeyStroke;
 import java.awt.event.InputEvent;
@@ -66,7 +67,8 @@ public class RepeatUndoExtension extends ImageViewerExtension {
                                                        KeyStroke.getKeyStroke(KeyEvent.VK_R, InputEvent.CTRL_DOWN_MASK),
                                                        repeatAction);
         prop.setAllowBlank(true);
-        prop.setReservedKeyStrokes(AppConfig.RESERVED_KEYSTROKES);
+        //prop.setReservedKeyStrokes(AppConfig.RESERVED_KEYSTROKES); // TODO does not work
+        prop.addFormFieldGenerationListener(new ReservedKeyStrokeWorkaround()); // Temporary workaround
         props.add(prop);
 
         prop = new KeyStrokeProperty(UNDO_PROP,
@@ -74,7 +76,8 @@ public class RepeatUndoExtension extends ImageViewerExtension {
                                      KeyStroke.getKeyStroke(KeyEvent.VK_Z, InputEvent.CTRL_DOWN_MASK),
                                      undoAction);
         prop.setAllowBlank(true);
-        prop.setReservedKeyStrokes(AppConfig.RESERVED_KEYSTROKES);
+        //prop.setReservedKeyStrokes(AppConfig.RESERVED_KEYSTROKES); // TODO does not work
+        prop.addFormFieldGenerationListener(new ReservedKeyStrokeWorkaround()); // Temporary workaround
         props.add(prop);
 
         return props;

--- a/src/main/java/ca/corbett/imageviewer/ui/ReservedKeyStrokeWorkaround.java
+++ b/src/main/java/ca/corbett/imageviewer/ui/ReservedKeyStrokeWorkaround.java
@@ -1,0 +1,32 @@
+package ca.corbett.imageviewer.ui;
+
+import ca.corbett.extras.properties.AbstractProperty;
+import ca.corbett.extras.properties.FormFieldGenerationListener;
+import ca.corbett.forms.fields.FormField;
+import ca.corbett.forms.fields.KeyStrokeField;
+import ca.corbett.imageviewer.AppConfig;
+
+/**
+ * This class works around a bug in KeyStrokeProperty where all attempts to set
+ * a list of reserved keystrokes are ignored. The workaround is to attach a
+ * FormFieldGenerationListener to the property, and set the reserved keystrokes
+ * list directly on the generated KeyStrokeField.
+ * <p>
+ * This bug was discovered in swing-extras 2.7, and is being tracked in
+ * <a href="https://github.com/scorbo2/swing-extras/issues/322">issue 322</a>.
+ * A future release of ImageViewer can remove this workaround once the bug
+ * is fixed in swing-extras.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class ReservedKeyStrokeWorkaround implements FormFieldGenerationListener {
+    @Override
+    public void formFieldGenerated(AbstractProperty property, FormField formField) {
+        if (!(formField instanceof KeyStrokeField keyStrokeField)) {
+            return;
+        }
+
+        keyStrokeField.setReservedKeyStrokes(AppConfig.RESERVED_KEYSTROKES);
+    }
+}

--- a/src/main/resources/ca/corbett/imageviewer/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/ReleaseNotes.txt
@@ -2,6 +2,7 @@ ImageViewer Release Notes
 Author: Steve Corbett
 
 Version 3.0 [TODO] - Maintenance release
+  #90 - Workaround for bug in KeyStrokeProperty
   #83 - Remove unused extension point: buildDirTree
   #82 - Clean up icon resource handling app-wide
   #80 - Remove KeyboardManager; use KeyStrokeManager instead


### PR DESCRIPTION
This bug addresses issue #90 by introducing a workaround for a bug in the `KeyStrokeProperty` class in swing-extras. The bug is unfortunately not going to be fixed in time for our 3.0 release, so we will have to live with this workaround.

Specific changes:
- introduce workaround class and document it. Reference the specific issue in swing-extras.
- Update all KeyStrokeProperties to use the workaround.
- Leave comments in the affected code areas to make it easier to remove the workaround later.
