### PR TITLE
Issue #72 - clean up commandline handling

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/Main.java
+++ b/src/main/java/ca/corbett/imageviewer/Main.java
@@ -30,6 +30,7 @@ public class Main {
 
         // Before we do anything else...
         initializeLogging();
+        Logger log = Logger.getLogger(Main.class.getName());
 
         // Check for -v command line arg:
         for (String arg : args) {
@@ -39,34 +40,18 @@ public class Main {
             }
         }
 
-        // This is extremely stupid, but due to the way ProcessBuilder handles command
-        // line arguments with spaces in the path or filename, we have to assume that if
-        // we receive multiple args, that it's actually Java being stupid on the calling
-        // end (i.e. Darwin) and that it is in fact a single path. So, join all arguments
-        // together with spaces and try to parse it into a single path.
+        // You can specify a directory on the command line to open at startup.
+        // You can also specify a fully-qualified image file, in which case we'll open
+        // its containing directory. Extra arguments beyond the first are ignored.
+        // If the given directory doesn't exist, it is logged and then ignored.
         File overrideDir = null;
         if (args.length > 0) {
-            StringBuilder path = new StringBuilder();
-
-            for (int i = 0; i < args.length; i++) {
-                path.append(args[i]);
-                if (i < args.length - 1) {
-                    path.append(" ");
-                }
-            }
-
-            File file = new File(path.toString());
+            File file = new File(args[0]);
             if (file.exists()) {
-
-                // You can specify a directory name, in which case we'll take it as-is:
-                if (file.isDirectory()) {
-                    overrideDir = file;
-                }
-
-                // Of you can specify a specific file, in which case we'll take it's containing dir:
-                else if (file.getParentFile().exists() && file.getParentFile().isDirectory()) {
-                    overrideDir = file.getParentFile();
-                }
+                overrideDir = file.isDirectory() ? file : file.getParentFile();
+            }
+            else {
+                log.severe("Startup directory does not exist: " + file.getAbsolutePath());
             }
         }
 
@@ -76,8 +61,7 @@ public class Main {
         final SplashScreen splashScreen = SplashScreen.getSplashScreen();
 
         // Load saved application config:
-        Logger.getLogger(Main.class.getName())
-              .info(Version.APPLICATION_NAME + " " + Version.VERSION + " initializing...");
+        log.info(Version.APPLICATION_NAME + " " + Version.VERSION + " initializing...");
         ImageViewerExtensionManager.getInstance().loadAll();
         AppConfig.getInstance().load();
         LookAndFeelManager.switchLaf(AppConfig.getInstance().getLookAndFeelClassname());

--- a/src/main/resources/ca/corbett/imageviewer/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/ReleaseNotes.txt
@@ -11,6 +11,7 @@ Version 3.0 [TODO] - Maintenance release
   #80 - Remove KeyboardManager; use KeyStrokeManager instead
   #76 - Upgrade to swing-extras 2.7
   #74 - Ensure image thumbnails are disposed properly
+  #72 - Clean up commandline handling
 
 Version 2.4 [2025-12-31] - Maintenance release
   #69 - Fix NullPointerException in AlienDialog


### PR DESCRIPTION
This PR addresses issue #72 by removing an old workaround in the application startup code related to a bug in the launcher script that has since been addressed. The bug was that the bash launcher script was using `$*` instead of `"$@"` to pass command-line arguments to this application, resulting in paths with spaces in them being handled incorrectly.

Did a quick test with the Darwin application launching ImageViewer with a startup directory containing a space, and confirmed that the old workaround is no longer needed.