### PR TITLE
Final touches for v3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ An installer tarball is available for linux-based systems. Just download, extrac
 the installer script to install the application:
 
 - [http://www.corbett.ca/apps/ImageViewer-3.0.tar.gz](http://www.corbett.ca/apps/ImageViewer-3.0.tar.gz)
-- TODO filesize
-- SHA-1: `TODO`
-- SHA-256: `TODO`
+- Size: 20MB
+- SHA-256: `3e2f02c1578220f2fccd5f841201f7907d4f26805de3b42c9c9fcb5a30836496`
 
 Alternatively, you can clone this repo and build it with Maven (Java 17 or higher required):
 

--- a/installer.props
+++ b/installer.props
@@ -8,7 +8,7 @@ FORMAT="tarball"
 
 # Application name/version will also be used for the jar file name.
 APPLICATION="ImageViewer"
-VERSION="3.0-SNAPSHOT"
+VERSION="3.0"
 CATEGORY="Graphics"
 
 PROJECT_URL="https://github.com/scorbo2/imageviewer"

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ca.corbett</groupId>
     <artifactId>imageviewer</artifactId>
-    <version>3.0-SNAPSHOT</version>
+    <version>3.0</version>
 
     <name>imageviewer</name>
     <description>ImageViewer - an extensible image viewer in Java Swing</description>

--- a/src/main/java/ca/corbett/imageviewer/Version.java
+++ b/src/main/java/ca/corbett/imageviewer/Version.java
@@ -82,7 +82,7 @@ public final class Version {
     static {
         aboutInfo = new AboutInfo();
         aboutInfo.applicationName = APPLICATION_NAME;
-        aboutInfo.applicationVersion = VERSION + "-SNAPSHOT"; // TODO remove -SNAPSHOT for releases
+        aboutInfo.applicationVersion = VERSION;
         aboutInfo.copyright = COPYRIGHT;
         aboutInfo.license = LICENSE;
         aboutInfo.projectUrl = PROJECT_URL;

--- a/src/main/resources/ca/corbett/imageviewer/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/ReleaseNotes.txt
@@ -1,7 +1,7 @@
 ImageViewer Release Notes
 Author: Steve Corbett
 
-Version 3.0 [TODO] - Major release with breaking API changes
+Version 3.0 [2026-03-13] - Major release with breaking API changes
   #114 - Optional log warning when thumb cache gets too big
   #112 - Improve UI performance when browsing large directories
   #108 - Add helper methods for extensions to access the thumb panel


### PR DESCRIPTION
Final touches for the 3.0 release. Remove SNAPSHOT from all version properties and update the README with file size and SHA-256 sum for the final installer tarball.
