### PR TITLE
Issue #117 - fix critical bug in AlienDialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ the installer script to install the application:
 
 - [http://www.corbett.ca/apps/ImageViewer-3.1.tar.gz](http://www.corbett.ca/apps/ImageViewer-3.1.tar.gz)
 - Size: 20MB
-- SHA-256: `4994dbe750f5409c01d3cdf19da3de966daad100fa756d1a8960cecae393f7d2`
+- SHA-256: `f1270ea8e2db95abc9a218858917d478f78322e191bb77b76595cc5c9e09e41b`
 
 Alternatively, you can clone this repo and build it with Maven (Java 17 or higher required):
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Features:
 An installer tarball is available for linux-based systems. Just download, extract, and run
 the installer script to install the application:
 
-- [http://www.corbett.ca/apps/ImageViewer-3.0.tar.gz](http://www.corbett.ca/apps/ImageViewer-3.0.tar.gz)
+- [http://www.corbett.ca/apps/ImageViewer-3.1.tar.gz](http://www.corbett.ca/apps/ImageViewer-3.1.tar.gz)
 - Size: 20MB
-- SHA-256: `3e2f02c1578220f2fccd5f841201f7907d4f26805de3b42c9c9fcb5a30836496`
+- SHA-256: `4994dbe750f5409c01d3cdf19da3de966daad100fa756d1a8960cecae393f7d2`
 
 Alternatively, you can clone this repo and build it with Maven (Java 17 or higher required):
 
@@ -28,7 +28,7 @@ mvn package
 
 # Run manually:
 cd target
-java -jar imageviewer-3.0.jar
+java -jar imageviewer-3.1.jar
 ```
 
 If you have [install-scripts](https://github.com/scorbo2/install-scripts) installed and you are running the build

--- a/installer.props
+++ b/installer.props
@@ -8,7 +8,7 @@ FORMAT="tarball"
 
 # Application name/version will also be used for the jar file name.
 APPLICATION="ImageViewer"
-VERSION="3.0"
+VERSION="3.1"
 CATEGORY="Graphics"
 
 PROJECT_URL="https://github.com/scorbo2/imageviewer"

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ca.corbett</groupId>
     <artifactId>imageviewer</artifactId>
-    <version>3.0</version>
+    <version>3.1</version>
 
     <name>imageviewer</name>
     <description>ImageViewer - an extensible image viewer in Java Swing</description>

--- a/src/main/java/ca/corbett/imageviewer/FallbackExceptionHandler.java
+++ b/src/main/java/ca/corbett/imageviewer/FallbackExceptionHandler.java
@@ -18,6 +18,5 @@ public class FallbackExceptionHandler implements Thread.UncaughtExceptionHandler
     @Override
     public void uncaughtException(Thread t, Throwable e) {
         log.log(Level.SEVERE, "Uncaught exception in thread " + t.getName() + ": " + e.getMessage(), e);
-        e.printStackTrace(); // this is the one place where printStackTrace() is acceptable :)
     }
 }

--- a/src/main/java/ca/corbett/imageviewer/FallbackExceptionHandler.java
+++ b/src/main/java/ca/corbett/imageviewer/FallbackExceptionHandler.java
@@ -10,6 +10,7 @@ import java.util.logging.Logger;
  * runtime exception effectively kill the app with nothing in the log.
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since ImageViewer 3.1
  */
 public class FallbackExceptionHandler implements Thread.UncaughtExceptionHandler {
 

--- a/src/main/java/ca/corbett/imageviewer/FallbackExceptionHandler.java
+++ b/src/main/java/ca/corbett/imageviewer/FallbackExceptionHandler.java
@@ -1,0 +1,23 @@
+package ca.corbett.imageviewer;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Fallback handler for any exception that goes uncaught in any thread.
+ * Basically we just want to make sure that the stack trace shows up
+ * in the log file. A recent incident (issue #117) had an uncaught
+ * runtime exception effectively kill the app with nothing in the log.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class FallbackExceptionHandler implements Thread.UncaughtExceptionHandler {
+
+    private static final Logger log = Logger.getLogger(FallbackExceptionHandler.class.getName());
+
+    @Override
+    public void uncaughtException(Thread t, Throwable e) {
+        log.log(Level.SEVERE, "Uncaught exception in thread " + t.getName() + ": " + e.getMessage(), e);
+        e.printStackTrace(); // this is the one place where printStackTrace() is acceptable :)
+    }
+}

--- a/src/main/java/ca/corbett/imageviewer/Main.java
+++ b/src/main/java/ca/corbett/imageviewer/Main.java
@@ -40,6 +40,9 @@ public class Main {
             }
         }
 
+        // For those pesky unchecked exceptions (this ensures they get logged):
+        Thread.setDefaultUncaughtExceptionHandler(new FallbackExceptionHandler());
+
         // You can specify a directory on the command line to open at startup.
         // You can also specify a fully-qualified image file, in which case we'll open
         // its containing directory. Extra arguments beyond the first are ignored.

--- a/src/main/java/ca/corbett/imageviewer/Version.java
+++ b/src/main/java/ca/corbett/imageviewer/Version.java
@@ -22,7 +22,7 @@ public final class Version {
     public static final int VERSION_MAJOR = 3;
 
     /** The minor (patch) version. **/
-    public static final int VERSION_MINOR = 0;
+    public static final int VERSION_MINOR = 1;
 
     /** A user-friendly version string in the form "MAJOR.MINOR" (example: "1.0"). **/
     public static final String VERSION = VERSION_MAJOR + "." + VERSION_MINOR;
@@ -31,7 +31,7 @@ public final class Version {
     public static final String APPLICATION_NAME = "ImageViewer";
 
     public static final String NAME = APPLICATION_NAME + " " + VERSION;
-    public static String COPYRIGHT = "Copyright © 2017-2025 Steve Corbett";
+    public static String COPYRIGHT = "Copyright © 2017-2026 Steve Corbett";
 
     /**
      * The directory where ImageViewer was installed -

--- a/src/main/java/ca/corbett/imageviewer/ui/ThumbContainerPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/ui/ThumbContainerPanel.java
@@ -29,6 +29,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * A container to show a list of ThumbPanel instances.
@@ -702,12 +703,11 @@ public final class ThumbContainerPanel extends JPanel {
      */
     public static List<File> findAlienFiles(File dir) {
         ImageViewerExtensionManager extManager = ImageViewerExtensionManager.getInstance();
-        List<File> unmodifiableList = FileSystemUtil.findFiles(dir, false)
-                                                    .stream()
-                                                    .filter(f -> !ImageUtil.isImageFile(f))
-                                                    .filter(f -> !extManager.isCompanionFile(f))
-                                                    .filter(f -> !extManager.isKnownFile(f))
-                                                    .toList();
-        return new ArrayList<>(unmodifiableList); // return a mutable list!
+        return FileSystemUtil.findFiles(dir, false)
+                             .stream()
+                             .filter(f -> !ImageUtil.isImageFile(f))
+                             .filter(f -> !extManager.isCompanionFile(f))
+                             .filter(f -> !extManager.isKnownFile(f))
+                             .collect(Collectors.toCollection(ArrayList::new));
     }
 }

--- a/src/main/java/ca/corbett/imageviewer/ui/ThumbContainerPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/ui/ThumbContainerPanel.java
@@ -702,11 +702,12 @@ public final class ThumbContainerPanel extends JPanel {
      */
     public static List<File> findAlienFiles(File dir) {
         ImageViewerExtensionManager extManager = ImageViewerExtensionManager.getInstance();
-        return FileSystemUtil.findFiles(dir, false)
-                             .stream()
-                             .filter(f -> !ImageUtil.isImageFile(f))
-                             .filter(f -> !extManager.isCompanionFile(f))
-                             .filter(f -> !extManager.isKnownFile(f))
-                             .toList();
+        List<File> unmodifiableList = FileSystemUtil.findFiles(dir, false)
+                                                    .stream()
+                                                    .filter(f -> !ImageUtil.isImageFile(f))
+                                                    .filter(f -> !extManager.isCompanionFile(f))
+                                                    .filter(f -> !extManager.isKnownFile(f))
+                                                    .toList();
+        return new ArrayList<>(unmodifiableList); // return a mutable list!
     }
 }

--- a/src/main/resources/ca/corbett/imageviewer/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/ReleaseNotes.txt
@@ -1,6 +1,9 @@
 ImageViewer Release Notes
 Author: Steve Corbett
 
+Version 3.1 [2026-03-15] - Critical bug fix
+  #117 - Critical bug: AlienDialog breaks filesystem navigation
+
 Version 3.0 [2026-03-13] - Major release with breaking API changes
   #114 - Optional log warning when thumb cache gets too big
   #112 - Improve UI performance when browsing large directories


### PR DESCRIPTION
This PR addresses issue #117 by fixing a critical bug in alien file handling. The `findAlienFiles()` helper method was using a Java stream operation to filter and return an unmodifiable list. The calling code was then attempting to mutate the returned list with `clear()`, resulting in an (unchecked) `UnsupportedOperationException`. 

Specific changes in this PR:
- Modified `findAlienFiles()` to return a regular mutable ArrayList
- Searched through the code to find all other stream operations and ensure no other mutability problems exist (none found)
- Added `FallbackExceptionHandler` to ensure that unchecked exceptions in future get logged
- Updated version properties and README for an immediate `3.1` release to fix this bug

Closes #117 