### PR TITLE
Issues #123, #124, and #125 for a quick 3.3 release

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_25" default="true" project-jdk-name="temurin-25" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ the installer script to install the application:
 
 - [http://www.corbett.ca/apps/ImageViewer-3.3.tar.gz](http://www.corbett.ca/apps/ImageViewer-3.3.tar.gz)
 - Size: 20MB
-- SHA-256: `TODO update me for 3.3`
+- SHA-256: `e5c9254ca2c9f5e78762195a87c3deb8126ee73ca5c28529dd7455997e6b2da6`
 
 Alternatively, you can clone this repo and build it with Maven (Java 25 or higher required):
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ the installer script to install the application:
 
 - [http://www.corbett.ca/apps/ImageViewer-3.3.tar.gz](http://www.corbett.ca/apps/ImageViewer-3.3.tar.gz)
 - Size: 20MB
-- SHA-256: `e5c9254ca2c9f5e78762195a87c3deb8126ee73ca5c28529dd7455997e6b2da6`
+- SHA-256: `37bbf6bb349601c84c8642c37963663e4c67a26e09caef44a2f902432850d897`
 
 Alternatively, you can clone this repo and build it with Maven (Java 25 or higher required):
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ the installer script to install the application:
 
 - [http://www.corbett.ca/apps/ImageViewer-3.3.tar.gz](http://www.corbett.ca/apps/ImageViewer-3.3.tar.gz)
 - Size: 20MB
-- SHA-256: `37bbf6bb349601c84c8642c37963663e4c67a26e09caef44a2f902432850d897`
+- SHA-256: `8fd1e704413e0d58a015472a52f14c6115f68ce448a3fccaa87bbdca610348f6`
 
 Alternatively, you can clone this repo and build it with Maven (Java 25 or higher required):
 

--- a/README.md
+++ b/README.md
@@ -15,20 +15,20 @@ Features:
 An installer tarball is available for linux-based systems. Just download, extract, and run
 the installer script to install the application:
 
-- [http://www.corbett.ca/apps/ImageViewer-3.2.tar.gz](http://www.corbett.ca/apps/ImageViewer-3.2.tar.gz)
+- [http://www.corbett.ca/apps/ImageViewer-3.3.tar.gz](http://www.corbett.ca/apps/ImageViewer-3.3.tar.gz)
 - Size: 20MB
-- SHA-256: `2e6c4b6a770cc8ef56a6125a47f89bc1d7fdf7a678c3c276797019ec26f2bf19`
+- SHA-256: `TODO update me for 3.3`
 
-Alternatively, you can clone this repo and build it with Maven (Java 17 or higher required):
+Alternatively, you can clone this repo and build it with Maven (Java 25 or higher required):
 
 ```shell
 git clone https://github.com/scorbo2/imageviewer.git
 cd imageviewer
-mvn package
+mvn package # requires Java 25 or higher!
 
 # Run manually:
 cd target
-java -jar imageviewer-3.2.jar
+java -jar imageviewer-3.3.jar
 ```
 
 If you have [install-scripts](https://github.com/scorbo2/install-scripts) installed and you are running the build

--- a/installer.props
+++ b/installer.props
@@ -17,6 +17,9 @@ OUTPUT_DIR=target
 # Extra memory settings like Xmx and Xms can be specified here:
 JAVAMEM=
 
+# Suppress the unnamed module warning for Java 24+:
+EXTRA_JAVA_ARGS="--enable-native-access=ALL-UNNAMED"
+
 # The application jar file:
 JAR="target/imageviewer-${VERSION}.jar"
 

--- a/installer.props
+++ b/installer.props
@@ -8,7 +8,7 @@ FORMAT="tarball"
 
 # Application name/version will also be used for the jar file name.
 APPLICATION="ImageViewer"
-VERSION="3.2"
+VERSION="3.3"
 CATEGORY="Graphics"
 
 PROJECT_URL="https://github.com/scorbo2/imageviewer"

--- a/installer.props
+++ b/installer.props
@@ -15,7 +15,7 @@ PROJECT_URL="https://github.com/scorbo2/imageviewer"
 OUTPUT_DIR=target
 
 # Extra memory settings like Xmx and Xms can be specified here:
-JAVAMEM=
+JAVA_MEM=
 
 # Suppress the unnamed module warning for Java 24+:
 EXTRA_JAVA_ARGS="--enable-native-access=ALL-UNNAMED"

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ca.corbett</groupId>
     <artifactId>imageviewer</artifactId>
-    <version>3.2</version>
+    <version>3.3</version>
 
     <name>imageviewer</name>
     <description>ImageViewer - an extensible image viewer in Java Swing</description>
@@ -35,8 +35,8 @@
     </scm>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>ca.corbett</groupId>
             <artifactId>swing-extras</artifactId>
-            <version>2.9.0</version>
+            <version>3.0.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/ca/corbett/imageviewer/Main.java
+++ b/src/main/java/ca/corbett/imageviewer/Main.java
@@ -67,7 +67,7 @@ public class Main {
         // Load saved application config:
         log.info(Version.APPLICATION_NAME + " " + Version.VERSION + " initializing...");
         ImageViewerExtensionManager.getInstance().loadAll();
-        AppConfig.getInstance().load();
+        AppConfig.getInstance().reinitialize(); // NOT load()! Some of our extensions may have messed with AppConfig...
         LookAndFeelManager.switchLaf(AppConfig.getInstance().getLookAndFeelClassname());
 
         // Load and show main window:

--- a/src/main/java/ca/corbett/imageviewer/Version.java
+++ b/src/main/java/ca/corbett/imageviewer/Version.java
@@ -22,7 +22,7 @@ public final class Version {
     public static final int VERSION_MAJOR = 3;
 
     /** The minor (patch) version. **/
-    public static final int VERSION_MINOR = 2;
+    public static final int VERSION_MINOR = 3;
 
     /** A user-friendly version string in the form "MAJOR.MINOR" (example: "1.0"). **/
     public static final String VERSION = VERSION_MAJOR + "." + VERSION_MINOR;

--- a/src/main/java/ca/corbett/imageviewer/ui/actions/LogConsoleAction.java
+++ b/src/main/java/ca/corbett/imageviewer/ui/actions/LogConsoleAction.java
@@ -2,6 +2,7 @@ package ca.corbett.imageviewer.ui.actions;
 
 import ca.corbett.extras.EnhancedAction;
 import ca.corbett.extras.logging.LogConsole;
+import ca.corbett.imageviewer.ui.MainWindow;
 
 import java.awt.event.ActionEvent;
 
@@ -13,6 +14,7 @@ import java.awt.event.ActionEvent;
 public class LogConsoleAction extends EnhancedAction {
 
     private static final String NAME = "Log console";
+    private static boolean positionAdjusted = false;
 
     public LogConsoleAction() {
         super(NAME);
@@ -21,6 +23,15 @@ public class LogConsoleAction extends EnhancedAction {
 
     @Override
     public void actionPerformed(ActionEvent e) {
+        // The first time LogConsole is shown, we'll position it over the MainWindow.
+        // But LogConsole is a singleton hide-when-closed window, so if the user adjusts
+        // its position manually after bringing it up, and then closes it, we don't want
+        // to mess with it again.
+        if (!positionAdjusted) {
+            LogConsole.getInstance().setLocationRelativeTo(MainWindow.getInstance());
+            positionAdjusted = true;
+        }
+
         LogConsole.getInstance().setVisible(true);
     }
 }

--- a/src/main/resources/ca/corbett/imageviewer/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/ReleaseNotes.txt
@@ -1,6 +1,11 @@
 ImageViewer Release Notes
 Author: Steve Corbett
 
+Version 3.3 [2026-06-22] - Maintenance release
+  #125 - Better initial positioning of LogConsole
+  #124 - Upgrade to swing-extras 3.0 / Java 25 - Windows fixes!
+  #123 - Fix AppConfig property loading problem on startup
+
 Version 3.2 [2026-04-19] - Maintenance release
   #119 - Upgrade to swing-extras 2.9 (minor bug fixes)
 


### PR DESCRIPTION
This PR prepares a quick `3.3` release with a few fixes and changes:

Closes #123 - Fix problem with AppConfig on startup, where a misbehaving extension could prevent AppConfig from being initialized properly. Invoking `reinitialize()` instead of `load()` right after activating all extensions forces AppConfig to properly initialize with all config properties.

Closes #124 - Upgrade to swing-extras `3.0` and migrate from Java 17 to Java 25 (latest LTS). The `3.0` release includes several Windows-specific bug fixes, and so is very good to pull in here.

Closes #125 - Cosmetic change regarding the initial positioning of the LogConsole window.

Closes #126 - suppress unnamed module warning on startup
